### PR TITLE
add configurable port for ADE

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
 					"launch": {
 						"required": [
 							"missionRoot",
-							"scriptPrefix"
+							"scriptPrefix",
+							"port"
 						],
 						"properties": {
 							"missionRoot": {
@@ -86,6 +87,11 @@
 								"type": "string",
 								"default": "${workspaceFolder}",
 								"description": "Ingame script prefix"
+							},
+							"port": {
+								"type": "number",
+								"default": 9002,
+								"description": "Port for Arma Debug Engine"
 							}
 						}
 					}

--- a/package.json.lang
+++ b/package.json.lang
@@ -58,7 +58,8 @@
 					"launch": {
 						"required": [
 							"missionRoot",
-							"scriptPrefix"
+							"scriptPrefix",
+							"port"
 						],
 						"properties": {
 							"missionRoot": {
@@ -70,6 +71,11 @@
 								"type": "string",
 								"default": "${workspaceFolder}",
 								"description": "Ingame script prefix"
+							},
+							"port": {
+								"type": "number",
+								"default": 9002,
+								"description": "Port for Arma Debug Engine"
 							}
 						}
 					}

--- a/src/arma-debug-engine.ts
+++ b/src/arma-debug-engine.ts
@@ -1,5 +1,6 @@
 import * as WebSocket from 'ws';
 import { EventEmitter } from 'events';
+import { SQFDebugSession } from './sqf-debug';
 
 
 export enum BreakpointAction
@@ -202,6 +203,7 @@ export class ArmaDebugEngine extends EventEmitter {
 
     logging:boolean = false;
     verbose:boolean = false;
+	port: number = SQFDebugSession.DEFAULT_PORT;
 
     breakpoints: { [key: number]: IBreakpointRequest } = {};
     breakpointId = 0;
@@ -246,8 +248,7 @@ export class ArmaDebugEngine extends EventEmitter {
                 resolve();
             });
             
-            const ADE_PORT = 9002;
-            this.client = new WebSocket(`ws://localhost:${ADE_PORT}`);
+            this.client = new WebSocket(`ws://localhost:${this.port}`);
             this.client.on('open', () => {
                 this.connected = true;
                 this.sendCommand(this.nextHandle(), Commands.getVersionInfo);
@@ -269,7 +270,7 @@ export class ArmaDebugEngine extends EventEmitter {
             
             this.client.on('error', (err:Error) => {
                 if((err as any)?.code === 'ECONNREFUSED') {
-                    this.error(`Could not connect to Arma Debug Engine`);
+                    this.error(`Could not connect to Arma Debug Engine on port: ${this.port}`);
                 } else {
                     this.error(`Socket error: ${err.message}`);
                 }
@@ -344,7 +345,7 @@ export class ArmaDebugEngine extends EventEmitter {
                 let json = JSON.parse(cmd);
                 json.handle = this.nextHandle();
                 this.send(json);
-                resolve();
+                resolve("");
             } catch (error) {
                 reject(error);
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,6 +118,7 @@ class SQFConfigurationProvider implements vscode.DebugConfigurationProvider {
 				config.program = '${file}';
 				config.missionRoot = '${workspaceFolder}';
 				config.scriptPrefix = '${workspaceFolder}';
+				config.port = SQFDebugSession.DEFAULT_PORT;
 				config.stopOnEntry = true;
 			}
 		}


### PR DESCRIPTION
This PR adds a configurable port for the websocket to communicate with ADE

Which allows debugging of the client and the server at the same time from the same source repo when the paths (missionRoot and scriptPrefix) for client and server are set correctly.

This requiers a custom build of ADE with a different port. (This [build ](https://cdn.discordapp.com/attachments/823197917929013269/1150511785259045004/BIDebugEngine_x64.dll) uses port 9003, this build also requiers `-intignorecert` to skipt cert checking in intercept)

Eventually the port in ADE can be made configurable.
