### PR TITLE
Added pull code content from Stackframe

### DIFF
--- a/src/arma-debug-engine.ts
+++ b/src/arma-debug-engine.ts
@@ -162,6 +162,7 @@ export interface ICallStackItem {
     };
     fileOffset?: { 0: number; 1: number; 2: number };
     compiled?: ICompiledInstruction[];
+    content?: string;
 }
 
 export interface IVariable extends IValue {


### PR DESCRIPTION
New ADE version https://github.com/dedmen/ArmaDebugEngine/commit/89a1949e4fdbaecfedf2a349a2137eca0e04109c will now include full code content, if there is no filename (so if there is no other way to load the content, like calling LoadFile on the filename)

So with this, also errors in scripts that were compiled without file information, and scripts executed in debug console, and remoteExec "call" script snippets, will be able to be viewed in VSCode when they trigger a halt.